### PR TITLE
Separate cluster creation from training in Optuna example

### DIFF
--- a/optuna-xgboost/optuna-xgboost.ipynb
+++ b/optuna-xgboost/optuna-xgboost.ipynb
@@ -69,23 +69,47 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Connect to Coiled"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask.distributed import Client\n",
     "import coiled\n",
+    "from dask.distributed import Client\n",
+    "\n",
+    "cluster = coiled.Cluster(\n",
+    "    n_workers=10, \n",
+    "    software=\"jrbourbeau/optuna\"\n",
+    ")\n",
+    "client = Client(cluster)\n",
+    "client.wait_for_workers(10)\n",
+    "\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train with Optuna"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import optuna\n",
     "import dask_optuna\n",
     "import joblib\n",
-    "\n",
-    "# Create a Dask cluster with Coiled\n",
-    "cluster = coiled.Cluster(n_workers=10, software=\"jrbourbeau/optuna\")\n",
-    "# Connect Dask to our cluster\n",
-    "client = Client(cluster)\n",
-    "print(f\"Dask dashboard is available at {client.dashboard_link}\")\n",
-    "client.wait_for_workers(10)\n",
     "\n",
     "# Create Dask-compatible Optuna storage class\n",
     "storage = dask_optuna.DaskStorage()\n",


### PR DESCRIPTION
This separates the cluster creation step to another cell.  This allows
people to hook up the dashboard before things run.  It also lets users
see what is cluster startup time vs what is Optuna train time.

Also, we use markdown titles rather than code comments, which might
improve readability a bit (although this is subjective).