### PR TITLE
Update to use examples account instead of coiled-examples

### DIFF
--- a/hyperband/create-notebook.py
+++ b/hyperband/create-notebook.py
@@ -14,9 +14,18 @@ conda = {
         "s3fs",
     ],
 }
-software_name = "coiled-examples/hyperband-optimization"
+
+# Create cluster software environment
+software_name = "examples/hyperband-optimization"
 coiled.create_software_environment(
     name=software_name,
+    conda=conda,
+)
+
+# Create notebook job software environment
+software_notebook_name = software_name + "-notebook"
+coiled.create_software_environment(
+    name=software_notebook_name,
     container="coiled/notebook:latest",
     conda=conda,
     pip=["coiled==0.0.27"]
@@ -24,7 +33,7 @@ coiled.create_software_environment(
 
 coiled.create_job_configuration(
     name="coiled/hyperband-optimization",
-    software=software_name,
+    software=software_notebook_name,
     command=[
         "/bin/bash",
         "run.sh",

--- a/hyperband/hyperband-optimization.ipynb
+++ b/hyperband/hyperband-optimization.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "cluster = coiled.Cluster(\n",
     "    n_workers=20,\n",
-    "    software=\"coiled-examples/hyperband-optimization\",\n",
+    "    software=\"examples/hyperband-optimization\",\n",
     ")"
    ]
   },

--- a/jupyterlab/create-notebook.py
+++ b/jupyterlab/create-notebook.py
@@ -1,6 +1,6 @@
 import coiled
 
-software_name = "coiled-examples/jupyterlab-notebook"
+software_name = "examples/jupyterlab-notebook"
 coiled.create_software_environment(
     name=software_name,
     container="coiled/notebook:latest",

--- a/optuna-xgboost/create-notebook.py
+++ b/optuna-xgboost/create-notebook.py
@@ -12,9 +12,18 @@ conda = {
     ],
 }
 
-software_name = "coiled-examples/optuna-xgboost-notebook"
+# Create cluster software environment
+software_name = "examples/optuna-xgboost"
 coiled.create_software_environment(
     name=software_name,
+    conda=conda,
+    pip=["dask-optuna"],
+)
+
+# Create notebook job software environment
+software_notebook_name = software_name + "-notebook"
+coiled.create_software_environment(
+    name=software_notebook_name,
     container="coiled/notebook:latest",
     conda=conda,
     pip=["dask-optuna", "coiled==0.0.27"],
@@ -22,7 +31,7 @@ coiled.create_software_environment(
 
 coiled.create_job_configuration(
     name="coiled/optuna",
-    software=software_name,
+    software=software_notebook_name,
     command=[
         "/bin/bash",
         "run.sh",

--- a/quickstart/create-notebook.py
+++ b/quickstart/create-notebook.py
@@ -1,6 +1,6 @@
 import coiled
 
-software_name = "coiled-examples/quickstart-notebook"
+software_name = "examples/quickstart-notebook"
 coiled.create_software_environment(
     name=software_name,
     container="coiled/notebook:latest",

--- a/scaling-xgboost/create-notebook.py
+++ b/scaling-xgboost/create-notebook.py
@@ -16,9 +16,17 @@ conda = {
     ],
 }
 
-software_name = "coiled-examples/scaling-xgboost-notebook"
+# Create cluster software environment
+software_name = "examples/scaling-xgboost"
 coiled.create_software_environment(
     name=software_name,
+    conda=conda,
+)
+
+# Create notebook job software environment
+software_notebook_name = software_name + "-notebook"
+coiled.create_software_environment(
+    name=software_notebook_name,
     container="coiled/notebook:latest",
     conda=conda,
     pip=["coiled==0.0.27"]
@@ -26,7 +34,7 @@ coiled.create_software_environment(
 
 coiled.create_job_configuration(
     name="coiled/scaling-xgboost",
-    software=software_name,
+    software=software_notebook_name,
     command=[
         "/bin/bash",
         "run.sh",

--- a/scaling-xgboost/scaling-xgboost.ipynb
+++ b/scaling-xgboost/scaling-xgboost.ipynb
@@ -179,7 +179,7 @@
    "source": [
     "### Create a Dask cluster on AWS with Coiled\n",
     "\n",
-    "Let's create a Coiled cluster using the `coiled-examples/xgboost` cluster configuration, which has Dask, XGBoost, Scikit-learn, and other relavant packages installed, and then connect a `dask.distributed.Client` to our cluster so we can begin to submit tasks to the cluster."
+    "Let's create a Coiled cluster using the `examples/xgboost` software environment, which has Dask, XGBoost, Scikit-learn, and other relavant packages installed, and then connect a `dask.distributed.Client` to our cluster so we can begin to submit tasks to the cluster."
    ]
   },
   {
@@ -192,7 +192,7 @@
     "\n",
     "cluster = coiled.Cluster(\n",
     "    n_workers=10,\n",
-    "    configuration=\"coiled-examples/xgboost\",\n",
+    "    software=\"examples/scaling-xgboost\",\n",
     ")"
    ]
   },


### PR DESCRIPTION
We recently switched to using an "examples" account instead of "coiled-examples" for storing example notebook software environments. This PR updates the code here accordingly. 