### PR TITLE
Explicitly include dask version in software environments and add github action to keep it up-to-date.

### DIFF
--- a/.github/workflows/ci-bump-dask.yml
+++ b/.github/workflows/ci-bump-dask.yml
@@ -1,4 +1,4 @@
-name: Check for new Coiled version on conda-forge
+name: Check for new dask version on conda-forge
 
 on:
   schedule:
@@ -11,19 +11,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Get latest Coiled version
+      - name: Get latest dask version
         id: latest_version
         uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
         with:
           org: "conda-forge"
-          package: "coiled"
+          package: "dask"
 
-      - name: Find and replace Coiled version
+      - name: Find and replace dask version
         id: find_and_replace
         uses: jacobtomlinson/gha-find-replace@0.1.1
         with:
-          find: "coiled=.*[0-9]+"
-          replace: "coiled=${{ steps.latest_version.outputs.version }}"
+          find: "dask=.*[0-9]+"
+          replace: "dask=${{ steps.latest_version.outputs.version }}"
           include: "create-notebook.py"
 
       - name: Output changed files
@@ -33,11 +33,11 @@ jobs:
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update Coiled version to ${{ steps.latest_version.outputs.version }}"
-          title: "Update Coiled version to ${{ steps.latest_version.outputs.version }}"
-          reviewers: "jrbourbeau"
+          commit-message: "Update dask version to ${{ steps.latest_version.outputs.version }}"
+          title: "Update dask version to ${{ steps.latest_version.outputs.version }}"
+          reviewers: "jrbourbeau,ian-r-rose"
           branch: "upgrade-package-versions"
           body: |
-            A new Coiled version has been detected.
+            A new dask version has been detected.
 
-            Updated Coiled to `${{ steps.latest_version.outputs.version }}`.
+            Updated dask to `${{ steps.latest_version.outputs.version }}`.

--- a/dask-sql/create-notebook.py
+++ b/dask-sql/create-notebook.py
@@ -4,7 +4,7 @@ conda = {
     "channels": ["conda-forge"],
     "dependencies": [
         "python=3.8",
-        "dask",
+        "dask=2021.03.0",
         "s3fs",
     ],
 }

--- a/hyperband/create-notebook.py
+++ b/hyperband/create-notebook.py
@@ -4,7 +4,7 @@ conda = {
     "channels": ["conda-forge", "pytorch", "defaults"],
     "dependencies": [
         "python=3.8",
-        "dask>=2.29.0",
+        "dask=2021.03.0",
         "coiled=0.0.37",
         "numpy",
         "pandas>=1.1.0",

--- a/jupyterlab/create-notebook.py
+++ b/jupyterlab/create-notebook.py
@@ -5,6 +5,7 @@ conda = {
     "dependencies": [
         "python=3.8",
         "traitlets=5.0.4",
+        "dask=2021.03.0",
         "coiled=0.0.37",
     ],
 }

--- a/optuna-xgboost/create-notebook.py
+++ b/optuna-xgboost/create-notebook.py
@@ -4,7 +4,7 @@ conda = {
     "channels": ["conda-forge"],
     "dependencies": [
         "python=3.8",
-        "dask",
+        "dask=2021.03.0",
         "coiled=0.0.37",
         "optuna",
         "numpy",

--- a/quickstart/create-notebook.py
+++ b/quickstart/create-notebook.py
@@ -6,7 +6,7 @@ coiled.create_software_environment(
     container="coiled/notebook:latest",
     conda={
         "channels": ["conda-forge"],
-        "dependencies": ["python=3.8", "coiled=0.0.37"],
+        "dependencies": ["python=3.8", "coiled=0.0.37", "dask=2021.03.0"]
     },
 )
 

--- a/scaling-xgboost/create-notebook.py
+++ b/scaling-xgboost/create-notebook.py
@@ -4,7 +4,7 @@ conda = {
     "channels": ["conda-forge"],
     "dependencies": [
         "python=3.8",
-        "dask>=2.23.0",
+        "dask=2021.03.0",
         "coiled=0.0.37",
         "pandas>=1.1.0",
         "xgboost",


### PR DESCRIPTION
Several of the example notebooks are currently broken due to dask version mismatches in the client/cluster software environments. Even though in theory this repo builds the two environments at the same time, coiled can still choose to use a cached version of a software environment matching the requested spec, which can (and does) lead to mismatches.

This includes an explicit dask version in the environment to ensure that it matches between client/cluster.