### PR TITLE
Update QuickStart notebook: Mention stopping clusters and software environments

### DIFF
--- a/quickstart/environment.yml
+++ b/quickstart/environment.yml
@@ -1,0 +1,8 @@
+name: coiled
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - coiled
+  - dask
+  - distributed

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Launch a cluster\n",
     "\n",
-    "The first step is to spin up a Dask Cluster. In coiled this is done by created a `coiled.Cluster` instance, there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.Cluster) you can use to further specify the details of your cluster. Please read the [cluster creation documentation](https://docs.coiled.io/user_guide/cluster_creation.html) to know more."
+    "The first step is to spin up a Dask Cluster. In Coiled, this is done by creating a `coiled.Cluster` instance, there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.Cluster) you can use to specify the details of your cluster further. Please read the [cluster creation documentation](https://docs.coiled.io/user_guide/cluster_creation.html) to know more."
    ]
   },
   {
@@ -33,7 +33,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once a cluster has been created (you can see the status on your [coiled dashboard](https://cloud.coiled.io/)), you can connect Dask to the cluster by creating a `distributed.Client` instance."
+    "Once a cluster has been created (you can see the status on your [Coiled dashboard](https://cloud.coiled.io/)), you can connect Dask to the cluster by creating a `distributed.Client` instance."
    ]
   },
   {
@@ -86,7 +86,7 @@
    "source": [
     "## Stop a cluster\n",
     "\n",
-    "By default, clusters will shutdown after 20 minutes of inactivity. You can stop a cluster by pressing the stop button on the [coiled dashboard](https://cloud.coiled.io/), alternatively, we can get a list of all running clusters and use the cluster name to stop it."
+    "By default, clusters will shutdown after 20 minutes of inactivity. You can stop a cluster by pressing the stop button on the [Coiled dashboard](https://cloud.coiled.io/). Alternatively, we can get a list of all running clusters and use the cluster name to stop it."
    ]
   },
   {
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can now go back to the [coiled dashboard](https://cloud.coiled.io/) and you will see that the cluster is now stopping/stopped"
+    "You can now go back to the [Coiled dashboard](https://cloud.coiled.io/) and you will see that the cluster is now stopping/stopped"
    ]
   },
   {
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now follow our previous workflow of creating a cluster - this time we will use our newly created software environment - connect the cluster to Dask and then running the same example."
+    "We can now follow our previous workflow of creating a cluster - this time, we will use our newly created software environment - connect the cluster to Dask and then running the same example."
    ]
   },
   {
@@ -192,7 +192,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you go to the [coiled dashboard](https://cloud.coiled.io/), under the **Software Environment** column, you can see that we are using the quickstart software environment we have just created."
+    "If you go to the [Coiled dashboard](https://cloud.coiled.io/), under the **Software Environment** column, you can see that we are using the quickstart software environment we have just created.\n",
+    "\n",
+    "Let's now run the same computation as before, but using the cluster that is running with the software environment that we have recently created."
    ]
   },
   {

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -150,26 +150,10 @@
     "coiled.create_software_environment(\n",
     "    name=\"quickstart\", \n",
     "    conda={\n",
-    "        \"channels\": [\"conda-forge\", \"defaults\"], \n",
-    "        \"dependencies\": [\"coiled\", \"dask\", \"distributed\"]\n",
+    "        \"channels\": [\"conda-forge\"], \n",
+    "        \"dependencies\": [\"coiled\"]\n",
     "    }\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, you can also use Coiled's CLI to create a software environment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!coiled env create --name quickstart --conda environment.yml"
    ]
   },
   {

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -15,7 +15,9 @@
    "source": [
     "## Launch a cluster\n",
     "\n",
-    "The first step is to spin up a Dask Cluster. In Coiled, this is done by creating a `coiled.Cluster` instance, there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.Cluster) you can use to specify the details of your cluster further. Please read the [cluster creation documentation](https://docs.coiled.io/user_guide/cluster_creation.html) to know more."
+    "The first step is to spin up a Dask Cluster. In Coiled, this is done by creating a `coiled.Cluster` instance, there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.Cluster) you can use to specify the details of your cluster further. Please read the [cluster creation documentation](https://docs.coiled.io/user_guide/cluster_creation.html) to know more.\n",
+    "\n",
+    "Note that we will give a name to this cluster, if you don't specify this keyword argument, clusters will be given a unique randomly generated name."
    ]
   },
   {
@@ -26,7 +28,7 @@
    "source": [
     "import coiled\n",
     "\n",
-    "cluster = coiled.Cluster(n_workers=10)"
+    "cluster = coiled.Cluster(name=\"quickstart-example\", n_workers=10)"
    ]
   },
   {
@@ -111,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coiled.delete_cluster(name=\"\") # Make sure to add the name of your running cluster here"
+    "coiled.delete_cluster(name=\"quickstart-example\")"
    ]
   },
   {
@@ -192,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you go to the [Coiled dashboard](https://cloud.coiled.io/), under the **Software Environment** column, you can see that we are using the quickstart software environment we have just created.\n",
+    "If you go to the [Coiled dashboard](https://cloud.coiled.io/), under the **Software Environment** column, you can see that we are using the quickstart software environment we have just created. Note also that this time, the cluster will have a randomly generated name.\n",
     "\n",
     "Let's now run the same computation as before, but using the cluster that is running with the software environment that we have recently created."
    ]

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "## Analyze data in the cloud\n",
     "\n",
-    "Now that we have our cluster running and Dask connected to it, let's run a computation. This example will run the computation on about about 84 million rows."
+    "Now that we have our cluster running and Dask connected to it, let's run a computation. This example will run the computation on about 84 million rows."
    ]
   },
   {
@@ -86,7 +86,7 @@
    "source": [
     "## Stop a cluster\n",
     "\n",
-    "By default clusters will shutdown after 20 minutes of inactivity. You can stop a cluster by pressing the stop button on the [coiled dashboard](https://cloud.coiled.io/), alternatively we can get a list of all running clusters and use the cluster name to stop it."
+    "By default, clusters will shutdown after 20 minutes of inactivity. You can stop a cluster by pressing the stop button on the [coiled dashboard](https://cloud.coiled.io/), alternatively, we can get a list of all running clusters and use the cluster name to stop it."
    ]
   },
   {
@@ -102,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The command `list_clusters` returns a dictionary with the cluster name used as key. We can grab that and then call the command `coiled.delete_cluster()` to stop the running cluster."
+    "The command `list_clusters` returns a dictionary with the cluster name used as the key. We can grab that and then call the command `coiled.delete_cluster()` to stop the running cluster."
    ]
   },
   {
@@ -136,7 +136,7 @@
    "source": [
     "## Create a software environment\n",
     "\n",
-    "When creating a software environments there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.create_software_environment) that you can use to create a custom environment for your work."
+    "When creating software environments, there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.create_software_environment) that you can use to create a custom environment for your work."
    ]
   },
   {
@@ -158,7 +158,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can know follow our previous workflow of creating a cluster - this time we will use our newly created software environment - connect the cluster to Dask and then running the same example."
+    "Alternatively, you can also use Coiled's CLI to create a software environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!coiled env create --name quickstart --conda environment.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now follow our previous workflow of creating a cluster - this time we will use our newly created software environment - connect the cluster to Dask and then running the same example."
    ]
   },
   {

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -4,14 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Getting started with Coiled"
+    "# Getting started with Coiled\n",
+    "\n",
+    "Welcome to the getting started guide for Coiled! This notebook covers installing and setting up Coiled as well as running your first computation using Coiled."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Launch a cluster"
+    "## Launch a cluster\n",
+    "\n",
+    "The first step is to spin up a Dask Cluster. In coiled this is done by created a `coiled.Cluster` instance, there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.Cluster) you can use to further specify the details of your cluster. Please read the [cluster creation documentation](https://docs.coiled.io/user_guide/cluster_creation.html) to know more."
    ]
   },
   {
@@ -21,17 +25,36 @@
    "outputs": [],
    "source": [
     "import coiled\n",
-    "from dask.distributed import Client\n",
     "\n",
-    "cluster = coiled.Cluster(n_workers=10)\n",
-    "client = Client(cluster)"
+    "cluster = coiled.Cluster(n_workers=10)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Analyze data in the cloud"
+    "Once a cluster has been created (you can see the status on your [coiled dashboard](https://cloud.coiled.io/)), you can connect Dask to the cluster by creating a `distributed.Client` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "\n",
+    "client = Client(cluster)\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyze data in the cloud\n",
+    "\n",
+    "Now that we have our cluster running and Dask connected to it, let's run a computation. This example will run the computation on about about 84 million rows."
    ]
   },
   {
@@ -42,6 +65,126 @@
    "source": [
     "import dask.dataframe as dd\n",
     "\n",
+    "df = dd.read_csv(\n",
+    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.csv\",\n",
+    "    dtype={\n",
+    "        \"payment_type\": \"UInt8\",\n",
+    "        \"VendorID\": \"UInt8\",\n",
+    "        \"passenger_count\": \"UInt8\",\n",
+    "        \"RatecodeID\": \"UInt8\",\n",
+    "    },\n",
+    "    storage_options={\"anon\": True},\n",
+    "    blocksize=\"16 MiB\",\n",
+    ").persist()\n",
+    "\n",
+    "df.groupby(\"passenger_count\").tip_amount.mean().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stop a cluster\n",
+    "\n",
+    "By default clusters will shutdown after 20 minutes of inactivity. You can stop a cluster by pressing the stop button on the [coiled dashboard](https://cloud.coiled.io/), alternatively we can get a list of all running clusters and use the cluster name to stop it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coiled.list_clusters()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The command `list_clusters` returns a dictionary with the cluster name used as key. We can grab that and then call the command `coiled.delete_cluster()` to stop the running cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coiled.delete_cluster(name=\"\") # Make sure to add the name of your running cluster here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can now go back to the [coiled dashboard](https://cloud.coiled.io/) and you will see that the cluster is now stopping/stopped"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Software Environments\n",
+    "\n",
+    "Software Environments are Docker images that contain all your dependencies and files that you might need to run your computations. If you don't specify a software environment to the `coiled.Cluster` constructor, we will use Coiled's default software environment. You can learn more about software environments in our [documentation](https://docs.coiled.io/user_guide/software_environment.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a software environment\n",
+    "\n",
+    "When creating a software environments there are [several keyword arguments](https://docs.coiled.io/user_guide/api.html#coiled.create_software_environment) that you can use to create a custom environment for your work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coiled.create_software_environment(\n",
+    "    name=\"quickstart\", \n",
+    "    conda={\n",
+    "        \"channels\": [\"conda-forge\", \"defaults\"], \n",
+    "        \"dependencies\": [\"coiled\", \"dask\", \"distributed\"]\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can know follow our previous workflow of creating a cluster - this time we will use our newly created software environment - connect the cluster to Dask and then running the same example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster = coiled.Cluster(n_workers=10, software=\"quickstart\")\n",
+    "client = Client(cluster)\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you go to the [coiled dashboard](https://cloud.coiled.io/), under the **Software Environment** column, you can see that we are using the quickstart software environment we have just created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "df = dd.read_csv(\n",
     "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.csv\",\n",
     "    dtype={\n",
@@ -74,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While chatting with @ndanielsen  about demoing, we think that the best way to show what coiled can do is by using the quickstart notebook. This PR explains what is happening and will link to parts of our documentation - it also mentions the coiled cluster dashboard a bit to check status.

One question that popped a few times was "how do I stop a cluster", so this is included. It might be worth touching briefly on the subject of software environments. As the last step, we create a simple software environment to show the user the workflow of creating software environments and then start a cluster and run the same computation as the one we did in the previous step.

@coiled/docs 