### PR TITLE
Update env name for quickstart environment

### DIFF
--- a/quickstart/environment.yml
+++ b/quickstart/environment.yml
@@ -1,4 +1,4 @@
-name: coiled
+name: quickstart
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
@FabioRosado I think that it's helpful to have an env file with the notebooks. 

Suggestion that we change the name of it to keep it from causing conflicts