### PR TITLE
Break environments into environment.yaml files so they can be reused more easily.

### DIFF
--- a/.github/workflows/ci-bump-version.yml
+++ b/.github/workflows/ci-bump-version.yml
@@ -25,7 +25,8 @@ jobs:
         with:
           find: "coiled=[.0-9]+"
           replace: "coiled=${{ steps.latest_version_coiled.outputs.version }}"
-          include: "create-notebook.py"
+          include: ".+\.ya?ml"
+          exclude: "^\.git.*"
 
       - name: Get latest dask version
         id: latest_version_dask
@@ -40,7 +41,9 @@ jobs:
         with:
           find: "dask=[.0-9]+"
           replace: "dask=${{ steps.latest_version_dask.outputs.version }}"
-          include: "create-notebook.py"
+          include: ".+\.ya?ml"
+          exclude: "^\.git.*"
+
 
       - name: Output changed files
         run: |

--- a/dask-sql/cluster-env.yaml
+++ b/dask-sql/cluster-env.yaml
@@ -1,0 +1,6 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- dask=2021.4.0
+- s3fs

--- a/dask-sql/create-notebook.py
+++ b/dask-sql/create-notebook.py
@@ -1,29 +1,19 @@
 import coiled
 
-conda = {
-    "channels": ["conda-forge"],
-    "dependencies": [
-        "python=3.8",
-        "dask=2021.4.0",
-        "s3fs",
-    ],
-}
-
 # Create cluster software environment
 software_name = "examples/dask-sql"
 coiled.create_software_environment(
     name=software_name,
-    conda=conda,
+    conda="cluster-env.yaml",
 )
 
 # Create notebook job software environment
 software_notebook_name = software_name + "-notebook"
 # Add Dask-SQL and matplotlib to notebook software environment
-conda["dependencies"].extend(["dask-sql", "matplotlib", "coiled=0.0.38"])
 coiled.create_software_environment(
     name=software_notebook_name,
     container="coiled/notebook:latest",
-    conda=conda,
+    conda="notebook-env.yaml",
 )
 
 coiled.create_job_configuration(

--- a/dask-sql/notebook-env.yaml
+++ b/dask-sql/notebook-env.yaml
@@ -1,0 +1,9 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- coiled=0.0.38
+- dask=2021.4.0
+- dask-sql
+- matplotlib
+- s3fs

--- a/hyperband/create-notebook.py
+++ b/hyperband/create-notebook.py
@@ -1,27 +1,10 @@
 import coiled
 
-conda = {
-    "channels": ["conda-forge", "pytorch", "defaults"],
-    "dependencies": [
-        "python=3.8",
-        "dask=2021.4.0",
-        "coiled=0.0.38",
-        "numpy",
-        "pandas>=1.1.0",
-        "dask-ml",
-        "skorch",
-        "scipy",
-        "matplotlib",
-        "pytorch>1.1.0",
-        "s3fs",
-    ],
-}
-
 # Create cluster software environment
 software_name = "examples/hyperband-optimization"
 coiled.create_software_environment(
     name=software_name,
-    conda=conda,
+    conda="environment.yaml",
 )
 
 # Create notebook job software environment
@@ -29,7 +12,7 @@ software_notebook_name = software_name + "-notebook"
 coiled.create_software_environment(
     name=software_notebook_name,
     container="coiled/notebook:latest",
-    conda=conda,
+    conda="environment.yaml",
 )
 
 coiled.create_job_configuration(

--- a/hyperband/environment.yaml
+++ b/hyperband/environment.yaml
@@ -1,0 +1,16 @@
+channels:
+- conda-forge
+- pytorch
+- defaults
+dependencies:
+- python=3.8
+- dask=2021.4.0
+- coiled=0.0.38
+- numpy
+- pandas>=1.1.0
+- dask-ml
+- skorch
+- scipy
+- matplotlib
+- pytorch>1.1.0
+- s3fs

--- a/jupyterlab/create-notebook.py
+++ b/jupyterlab/create-notebook.py
@@ -1,19 +1,10 @@
 import coiled
 
-conda = {
-    "channels": ["conda-forge"],
-    "dependencies": [
-        "python=3.8",
-        "traitlets=5.0.4",
-        "dask=2021.4.0",
-        "coiled=0.0.38",
-    ],
-}
 software_name = "examples/jupyterlab-notebook"
 coiled.create_software_environment(
     name=software_name,
     container="coiled/notebook:latest",
-    conda=conda,
+    conda="environment.yaml",
 )
 
 coiled.create_job_configuration(
@@ -25,5 +16,5 @@ coiled.create_job_configuration(
     ],
     files=["jupyterlab.ipynb", "workspace.json", "run.sh", "dask-extension.png"],
     ports=[8888],
-    description="See how Coiled intergrates with JupyterLab",
+    description="See how Coiled integrates with JupyterLab",
 )

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -1,0 +1,7 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- traitlets=5.0.4
+- coiled=0.0.38
+- dask=2021.4.0

--- a/optuna-xgboost/create-notebook.py
+++ b/optuna-xgboost/create-notebook.py
@@ -1,25 +1,10 @@
 import coiled
 
-conda = {
-    "channels": ["conda-forge"],
-    "dependencies": [
-        "python=3.8",
-        "dask=2021.4.0",
-        "coiled=0.0.38",
-        "optuna",
-        "numpy",
-        "scikit-learn",
-        "xgboost",
-        "joblib",
-    ],
-}
-
 # Create cluster software environment
 software_name = "examples/optuna-xgboost"
 coiled.create_software_environment(
     name=software_name,
-    conda=conda,
-    pip=["dask-optuna"],
+    conda="environment.yaml",
 )
 
 # Create notebook job software environment
@@ -27,8 +12,7 @@ software_notebook_name = software_name + "-notebook"
 coiled.create_software_environment(
     name=software_notebook_name,
     container="coiled/notebook:latest",
-    conda=conda,
-    pip=["dask-optuna"],
+    conda="environment.yaml",
 )
 
 coiled.create_job_configuration(

--- a/optuna-xgboost/environment.yaml
+++ b/optuna-xgboost/environment.yaml
@@ -1,0 +1,13 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- dask=2021.4.0
+- coiled=0.0.38
+- optuna
+- numpy
+- scikit-learn
+- xgboost
+- joblib
+- pip: 
+  - dask-optuna

--- a/quickstart/create-notebook.py
+++ b/quickstart/create-notebook.py
@@ -4,10 +4,7 @@ software_name = "examples/quickstart-notebook"
 coiled.create_software_environment(
     name=software_name,
     container="coiled/notebook:latest",
-    conda={
-        "channels": ["conda-forge"],
-        "dependencies": ["python=3.8", "coiled=0.0.38", "dask=2021.4.0"]
-    },
+    conda="environment.yaml"
 )
 
 coiled.create_job_configuration(

--- a/quickstart/environment.yaml
+++ b/quickstart/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- coiled=0.0.38
+- dask=2021.4.0

--- a/quickstart/environment.yml
+++ b/quickstart/environment.yml
@@ -1,8 +1,0 @@
-name: coiled
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - coiled
-  - dask
-  - distributed

--- a/scaling-xgboost/create-notebook.py
+++ b/scaling-xgboost/create-notebook.py
@@ -1,28 +1,10 @@
 import coiled
 
-conda = {
-    "channels": ["conda-forge"],
-    "dependencies": [
-        "python=3.8",
-        "dask=2021.4.0",
-        "coiled=0.0.38",
-        "pandas>=1.1.0",
-        "xgboost",
-        "dask-ml",
-        "dask-xgboost",
-        "scikit-learn",
-        "s3fs",
-        "python-snappy",
-        "fastparquet",
-        "matplotlib",
-    ],
-}
-
 # Create cluster software environment
 software_name = "examples/scaling-xgboost"
 coiled.create_software_environment(
     name=software_name,
-    conda=conda,
+    conda="environment.yaml",
 )
 
 # Create notebook job software environment
@@ -30,7 +12,7 @@ software_notebook_name = software_name + "-notebook"
 coiled.create_software_environment(
     name=software_notebook_name,
     container="coiled/notebook:latest",
-    conda=conda,
+    conda="environment.yaml",
 )
 
 coiled.create_job_configuration(

--- a/scaling-xgboost/environment.yaml
+++ b/scaling-xgboost/environment.yaml
@@ -1,0 +1,15 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- dask>=2021.4.0
+- coiled=0.0.38
+- pandas>=1.1.0
+- xgboost
+- dask-ml
+- dask-xgboost
+- scikit-learn
+- s3fs
+- python-snappy
+- fastparquet
+- matplotlib


### PR DESCRIPTION
Over in `coiled/integration-tests` I'm trying to test these -- it would be useful to have separate `environment.yml` files to more easily drive them. Any objections @jrbourbeau?