### PR TITLE
deal with faulty escape

### DIFF
--- a/.github/workflows/ci-bump-version.yml
+++ b/.github/workflows/ci-bump-version.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           find: "coiled=[.0-9]+"
           replace: "coiled=${{ steps.latest_version_coiled.outputs.version }}"
-          include: ".+\.ya?ml"
-          exclude: "^\.git.*"
+          include: .+\.ya?ml
+          exclude: ^\.git.*
 
       - name: Get latest dask version
         id: latest_version_dask
@@ -41,8 +41,8 @@ jobs:
         with:
           find: "dask=[.0-9]+"
           replace: "dask=${{ steps.latest_version_dask.outputs.version }}"
-          include: ".+\.ya?ml"
-          exclude: "^\.git.*"
+          include: .+\.ya?ml
+          exclude: ^\.git.*
 
 
       - name: Output changed files


### PR DESCRIPTION
The regex was valid, but the yaml wasn't