### PR TITLE
Make sure start command is run in the right env.

### DIFF
--- a/jupyterlab/create-notebook.py
+++ b/jupyterlab/create-notebook.py
@@ -11,6 +11,11 @@ coiled.create_job_configuration(
     name="examples/jupyterlab",
     software=software_name,
     command=[
+        "conda",
+        "run",
+        "-n",
+        "coiled",
+        "--no-capture-output",
         "/bin/bash",
         "run.sh",
     ],


### PR DESCRIPTION
Since this environment doesn't have any additional packages, we never prepend the right conda bin directory. This explains the odd behavior we saw earlier today @jrbourbeau .

A better fix would fix would simultaneously fix coiled/cloud#1842 by maybe making this the entrypoint in the base image