### PR TITLE
Remove fastparquet from environment

### DIFF
--- a/scaling-xgboost/environment.yaml
+++ b/scaling-xgboost/environment.yaml
@@ -4,11 +4,11 @@ dependencies:
 - dask>=2021.4.0
 - coiled=0.0.38
 - pandas>=1.1.0
+- python=3.9
+- python-snappy
 - xgboost
 - dask-ml
 - dask-xgboost
 - scikit-learn
 - s3fs
-- python-snappy
-- fastparquet
 - matplotlib


### PR DESCRIPTION
Our bump to python3.9 in the base image broke the xgboost example because fastparquet isn't available on python3.9 through conda-forge.  The good news is that it isn't needed in this example.