### PR TITLE
Find/replace action failing on last coiled version, so bump manually until we publish a new one.

### DIFF
--- a/dask-sql/cluster-env.yaml
+++ b/dask-sql/cluster-env.yaml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- dask=2021.4.1
+- dask=2021.5.0
 - s3fs

--- a/dask-sql/notebook-env.yaml
+++ b/dask-sql/notebook-env.yaml
@@ -1,8 +1,8 @@
 channels:
 - conda-forge
 dependencies:
-- coiled=0.0.39
-- dask=2021.4.1
+- coiled=0.0.39.1
+- dask=2021.5.0
 - dask-sql
 - matplotlib
 - s3fs

--- a/hyperband/environment.yaml
+++ b/hyperband/environment.yaml
@@ -3,8 +3,8 @@ channels:
 - pytorch
 - defaults
 dependencies:
-- dask=2021.4.1
-- coiled=0.0.39
+- dask=2021.5.0
+- coiled=0.0.39.1
 - numpy
 - pandas>=1.1.0
 - skorch

--- a/jupyterlab/environment.yaml
+++ b/jupyterlab/environment.yaml
@@ -2,5 +2,5 @@ channels:
 - conda-forge
 dependencies:
 - traitlets=5.0.4
-- coiled=0.0.39
-- dask=2021.4.1
+- coiled=0.0.39.1
+- dask=2021.5.0

--- a/optuna-xgboost/environment.yaml
+++ b/optuna-xgboost/environment.yaml
@@ -1,8 +1,8 @@
 channels:
 - conda-forge
 dependencies:
-- dask=2021.4.1
-- coiled=0.0.39
+- dask=2021.5.0
+- coiled=0.0.39.1
 - optuna=2.3.0
 - numpy
 - scikit-learn

--- a/quickstart/environment.yaml
+++ b/quickstart/environment.yaml
@@ -1,5 +1,5 @@
 channels:
 - conda-forge
 dependencies:
-- coiled=0.0.39
-- dask=2021.4.1
+- coiled=0.0.39.1
+- dask=2021.5.0

--- a/scaling-xgboost/environment.yaml
+++ b/scaling-xgboost/environment.yaml
@@ -1,8 +1,8 @@
 channels:
 - conda-forge
 dependencies:
-- dask>=2021.4.0
-- coiled=0.0.39
+- dask>=2021.5.0
+- coiled=0.0.39.1
 - pandas>=1.1.0
 - python=3.9
 - python-snappy


### PR DESCRIPTION
Another reason to at least drop a zero from the `coiled` version.