### PR TITLE
Try not to overwhelm workers

### DIFF
--- a/dask-sql/dask-sql.ipynb
+++ b/dask-sql/dask-sql.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "cluster = coiled.Cluster(\n",
     "    n_workers=10,\n",
+    "    worker_memory=\"30GiB\",\n",
     "    software=\"examples/dask-sql\",\n",
     ")\n",
     "cluster"
@@ -44,6 +45,7 @@
     "from dask.distributed import Client\n",
     "\n",
     "client = Client(cluster)\n",
+    "client.wait_for_workers()\n",
     "client"
    ]
   },

--- a/jupyterlab/jupyterlab.ipynb
+++ b/jupyterlab/jupyterlab.ipynb
@@ -54,7 +54,8 @@
    "source": [
     "from dask.distributed import Client\n",
     "\n",
-    "client = Client(cluster)"
+    "client = Client(cluster)\n",
+    "client.wait_for_workers()"
    ]
   },
   {


### PR DESCRIPTION
These examples fail frequently due to workers running out of memory: trying to wait for them to all be up and increase the memory for
`dask-sql`.