### PR TITLE
Bump anaconda-package-version version to hopefully handle tricky version numbers a bit better

### DIFF
--- a/.github/workflows/ci-bump-version.yml
+++ b/.github/workflows/ci-bump-version.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get latest Coiled version
         id: latest_version_coiled
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.1
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
         with:
           org: "conda-forge"
           package: "coiled"


### PR DESCRIPTION
The previous version had some strict assumptions about the version string, this one fails a bit more gracefully thanks to the work of some of our pangeo colleagues