### PR TITLE
Bump worker CPU for dask-sql notebook

### DIFF
--- a/dask-sql/dask-sql.ipynb
+++ b/dask-sql/dask-sql.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "cluster = coiled.Cluster(\n",
     "    n_workers=10,\n",
+    "    worker_cpu=4,\n",
     "    worker_memory=\"30GiB\",\n",
     "    software=\"examples/dask-sql\",\n",
     ")\n",


### PR DESCRIPTION
Our default cluster decreased the number of worker CPUs, and the resulting cpu/memory combination isn't supported on ECS. Bump the cpus
back up.