### PR TITLE
max parallel builds = 1

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         example:
           [


### PR DESCRIPTION
Currently building too many concurrent environments can take down the application. We are working on a fix, but for now build sequentially.