### PR TITLE
Make sure we are tracking the dask/coiled version in the quickstart notebook

### DIFF
--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -152,7 +152,7 @@
     "    name=\"quickstart\", \n",
     "    conda={\n",
     "        \"channels\": [\"conda-forge\"], \n",
-    "        \"dependencies\": [\"coiled\"]\n",
+    "        \"dependencies\": [\"coiled==0.0.45\", \"dask==2021.7.2\"]\n",
     "    }\n",
     ")"
    ]


### PR DESCRIPTION
This is causing issues when new version are released that are backwards incompatible